### PR TITLE
Upgrade to Spring 6.0

### DIFF
--- a/.github/workflows/mvn-build.yml
+++ b/.github/workflows/mvn-build.yml
@@ -1,4 +1,4 @@
-name: "CI - JDK 11 Build"
+name: "CI - JDK 17 Build"
 
 on:
   push:
@@ -9,16 +9,16 @@ on:
 
 jobs:
   build-jdk11:
-    name: "JDK 11 Build"
+    name: "JDK 17 Build"
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - name: Build
         run: mvn clean install
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>io.quarkus</groupId>
   <artifactId>quarkus-spring-api</artifactId>
-  <version>5.2.SP8-SNAPSHOT</version>
+  <version>6.0.Final-SNAPSHOT</version>
 
   <name>Spring dependencies for Quarkus Spring DI extension</name>
   <description>The minimum dependencies to reduce the footprint of Quarkus applications using the Spring DI extension</description>
@@ -41,7 +41,7 @@
     <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <spring-framework.version>5.2.20.RELEASE</spring-framework.version>
+    <spring-framework.version>6.0.7</spring-framework.version>
   </properties>
 
   <packaging>pom</packaging>

--- a/quarkus-spring-beans-api/pom.xml
+++ b/quarkus-spring-beans-api/pom.xml
@@ -4,12 +4,12 @@
 
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-spring-beans-api</artifactId>
-    <version>5.2.SP8-SNAPSHOT</version>
+    <version>6.0.Final-SNAPSHOT</version>
 
     <parent>
         <artifactId>quarkus-spring-api</artifactId>
         <groupId>io.quarkus</groupId>
-        <version>5.2.SP8-SNAPSHOT</version>
+        <version>6.0.Final-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/quarkus-spring-context-api/pom.xml
+++ b/quarkus-spring-context-api/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>quarkus-spring-api</artifactId>
         <groupId>io.quarkus</groupId>
-        <version>5.2.SP8-SNAPSHOT</version>
+        <version>6.0.Final-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-spring-context-api</artifactId>
-    <version>5.2.SP8-SNAPSHOT</version>
+    <version>6.0.Final-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/quarkus-spring-core-api/pom.xml
+++ b/quarkus-spring-core-api/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <artifactId>quarkus-spring-api</artifactId>
         <groupId>io.quarkus</groupId>
-        <version>5.2.SP8-SNAPSHOT</version>
+        <version>6.0.Final-SNAPSHOT</version>
         <relativePath>../</relativePath>
     </parent>
 
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-spring-core-api</artifactId>
-    <version>5.2.SP8-SNAPSHOT</version>
+    <version>6.0.Final-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
@@ -58,6 +58,7 @@
                                         <include>org/springframework/util/Assert**</include>
                                         <include>org/springframework/util/ClassUtils**</include>
                                         <include>org/springframework/util/CollectionUtils**</include>
+                                        <include>org/springframework/util/ConcurrentLruCache**</include>
                                         <include>org/springframework/util/ConcurrentReferenceHashMap**</include>
                                         <include>org/springframework/util/LinkedMultiValueMap**</include>
                                         <include>org/springframework/util/MultiValueMap**</include>

--- a/quarkus-spring-web-api/pom.xml
+++ b/quarkus-spring-web-api/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-api</artifactId>
-        <version>5.2.SP8-SNAPSHOT</version>
+        <version>6.0.Final-SNAPSHOT</version>
     </parent>
 
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-spring-web-api</artifactId>
-    <version>5.2.SP8-SNAPSHOT</version>
+    <version>6.0.Final-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
@@ -76,6 +76,7 @@
                                         <include>org/springframework/http/HttpOutputMessage**</include>
                                         <include>org/springframework/http/HttpRange**</include>
                                         <include>org/springframework/http/InvalidMediaTypeException**</include>
+                                        <include>org/springframework/http/ProblemDetail**</include>
                                         <include>org/springframework/http/ReadOnlyHttpHeaders**</include>
                                         <include>org/springframework/http/RequestEntity**</include>
                                         <include>org/springframework/http/MediaType**</include>
@@ -86,6 +87,8 @@
                                         </include>
                                         <include>org/springframework/http/converter/HttpMessageNotWritableException**
                                         </include>
+                                        <include>org/springframework/web/ErrorResponse**</include>
+                                        <include>org/springframework/web/ErrorResponseException**</include>
                                         <include>org/springframework/web/WebApplicationInitializer**</include>
                                         <include>org/springframework/web/bind/annotation/ControllerAdvice**</include>
                                         <include>org/springframework/web/bind/annotation/RequestMethod**</include>

--- a/quarkus-spring-webmvc-api/pom.xml
+++ b/quarkus-spring-webmvc-api/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-spring-api</artifactId>
-        <version>5.2.SP8-SNAPSHOT</version>
+        <version>6.0.Final-SNAPSHOT</version>
     </parent>
 
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-spring-webmvc-api</artifactId>
-    <version>5.2.SP8-SNAPSHOT</version>
+    <version>6.0.Final-SNAPSHOT</version>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Relates to https://github.com/quarkusio/quarkus/issues/32027

I'll open a draft PR on Quarkus to show the impacts, I have spring-* extensions and integration-tests passing locally using a SNAPSHOT version.

Note: Spring 6 uses Java 17 bytecode, so once updating quarkus-spring-* extensions will only support JDK17+